### PR TITLE
Fixing global/user cooldown issues

### DIFF
--- a/src/twitch.js
+++ b/src/twitch.js
@@ -29,13 +29,15 @@ class TwitchShufflerListener {
     let lastCommandTimestampGlobal = this.lastCommandTimestamps['$$global$$'] || 0;
 
     if(config.chatCooldownGlobal && lastCommandTimestampGlobal > 0 && (lastCommandTimestampGlobal - now) <= config.chatCooldownGlobal) {
-      let cooldownLeft = -1;
-      logger.info(chalk.grey(`Ignoring swap due to the global cooldown ${cooldownLeft}`));
-      this.say(`@${user} command ${command} has ${cooldownLeft}s left the cooldown.`);
+      let cooldownLeft = Math.round(config.chatCooldownGlobal - (lastCommandTimestampGlobal - now));
+      let message = `@${user} command ${command} has ${cooldownLeft / 1000}s left for global cooldown.`;
+      logger.info(chalk.grey(message));
+      this.say(message);
     } else if(config.chatCooldownUser && lastCommandTimestamp > 0 && (lastCommandTimestamp - now) <= config.chatCooldownUser) {
-      let cooldownLeft = -1;
-      logger.info(chalk.grey(`Ignoring swap due to the user cooldown ${cooldownLeft}`));
-      this.say(`@${user} command ${command} has ${cooldownLeft}s left the cooldown.`);
+      let cooldownLeft = Math.round(config.chatCooldownUser - (lastCommandTimestamp - now));
+      let message = `@${user} command ${command} has ${cooldownLeft / 1000}s left for user cooldown.`;
+      logger.info(chalk.grey(message));
+      this.say(message);
     } else {
       isCoolingDown = false;
     }

--- a/src/twitch.js
+++ b/src/twitch.js
@@ -28,14 +28,14 @@ class TwitchShufflerListener {
     let lastCommandTimestamp = this.lastCommandTimestamps[user] || 0;
     let lastCommandTimestampGlobal = this.lastCommandTimestamps['$$global$$'] || 0;
 
-    if(config.chatCooldownGlobal && lastCommandTimestampGlobal > 0 && (lastCommandTimestampGlobal - now) <= config.chatCooldownGlobal) {
-      let cooldownLeft = Math.round(config.chatCooldownGlobal - (lastCommandTimestampGlobal - now));
-      let message = `@${user} command ${command} has ${cooldownLeft / 1000}s left for global cooldown.`;
+    if(config.chatCooldownUser && lastCommandTimestamp > 0 && (now - lastCommandTimestamp) <= config.chatCooldownUser) {
+      let cooldownLeft = config.chatCooldownUser - (now - lastCommandTimestamp );
+      let message = `@${user} command ${command} has ${Math.round(cooldownLeft / 1000)}s left for user cooldown.`;
       logger.info(chalk.grey(message));
       this.say(message);
-    } else if(config.chatCooldownUser && lastCommandTimestamp > 0 && (lastCommandTimestamp - now) <= config.chatCooldownUser) {
-      let cooldownLeft = Math.round(config.chatCooldownUser - (lastCommandTimestamp - now));
-      let message = `@${user} command ${command} has ${cooldownLeft / 1000}s left for user cooldown.`;
+    } else if(config.chatCooldownGlobal && lastCommandTimestampGlobal > 0 && (now - lastCommandTimestampGlobal) <= config.chatCooldownGlobal) {
+      let cooldownLeft = config.chatCooldownGlobal - (now - lastCommandTimestampGlobal);
+      let message = `@${user} command ${command} has ${Math.round(cooldownLeft / 1000)}s left for global cooldown.`;
       logger.info(chalk.grey(message));
       this.say(message);
     } else {

--- a/src/twitch.spec.js
+++ b/src/twitch.spec.js
@@ -133,6 +133,20 @@ describe('twitch', () => {
 
         expect(isCoolingDown).to.eql(true);
       });
+
+      it('should display a message on cooldown', () => {
+        listener.lastCommandTimestamps['$$global$$'] = new Date().getTime() + 1000;
+        listener.say = sinon.spy();
+
+        listener.isCoolingDown(
+          "fake_user",
+          "fake_command",
+          "fake_message",
+          {},
+        );
+
+        expect(listener.say.args[0][0]).to.match(/has 59s left/);
+      });
     });
 
     describe('user', () => {
@@ -186,6 +200,23 @@ describe('twitch', () => {
 
         expect(isCoolingDown).to.eql(false);
       });
+
+      it('should display a message on cooldown', () => {
+         listener.lastCommandTimestamps = {
+          'fake_user': new Date().getTime() + 1000,
+        };
+        listener.say = sinon.spy();
+
+        listener.isCoolingDown(
+          "fake_user",
+          "fake_command",
+          "fake_message",
+          {},
+        );
+
+        expect(listener.say.args[0][0]).to.match(/has 59s left/);
+      });
+
     });
 
     describe('global+user', () => {


### PR DESCRIPTION
This change fixes an issue in which the cooldown would reset when the swap command was used before the cooldown has ended. This would run intoa situation where a user would use the swap command and then other users
may not be able to use the swap command.