### PR TITLE
Adding requireInput property

### DIFF
--- a/src/swap.js
+++ b/src/swap.js
@@ -26,6 +26,11 @@ class RomShuffler {
         index = null;
       }
 
+      if(config.requireInput && !index) {
+        logger.info(chalk.grey(`Swap ignored since requireInput is true`));
+        return;
+      }
+
       if(index) {
         index = index.trim();
       }


### PR DESCRIPTION
Adding `requireInput` property for situations where the player wants the rom to be chosen (or there is a hidden rom) rather than random