### PR TITLE
Adding a config option to ignore rom files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ The shuffler can be configured by adding a `config.json` file (an example is pro
 
 > Configures the list chat command (e.g !list) to respond to (default: ^list$)
 
+#### ignoreRomsPattern
+
+> Filter out certain files in the current roms folder from being listed and used
+
 #### redemptionName
 
 > Configures the redpemption name to respond to (default: ^swap$)

--- a/src/common.js
+++ b/src/common.js
@@ -4,7 +4,6 @@ exports.filterRomsFromPattern = (ignoreRomsPattern) => (rom) => {
         return true;
     } else {
         const ignoreRomsRegExp = new RegExp(ignoreRomsPattern);
-        console.log(ignoreRomsRegExp.test(rom), rom)
         return (ignoreRomsRegExp.test(rom) === false);
     }
 }

--- a/src/common.js
+++ b/src/common.js
@@ -1,0 +1,10 @@
+
+exports.filterRomsFromPattern = (ignoreRomsPattern) => (rom) => {
+    if(!ignoreRomsPattern) {
+        return true;
+    } else {
+        const ignoreRomsRegExp = new RegExp(ignoreRomsPattern);
+        console.log(ignoreRomsRegExp.test(rom), rom)
+        return (ignoreRomsRegExp.test(rom) === false);
+    }
+}

--- a/src/common.spec.js
+++ b/src/common.spec.js
@@ -1,0 +1,45 @@
+const { expect } = require('chai');
+
+const common = require('./common');
+
+describe('filterRomsFromPattern', () => {
+    it('should filter roms based on patters', () => {
+        const roms =  [
+            '1_Foo.nes',
+            '2_Bar.bin',
+        ];
+
+        const pattern = "\.bin";
+
+        const result = roms.filter(common.filterRomsFromPattern(pattern));
+
+        expect(result[0]).to.eql('1_Foo.nes');
+        expect(result.length).to.eql(1);
+    });
+
+    it('should filter roms based on patters', () => {
+        const roms =  [
+            '1_Foo.nes',
+            '2_Bar.bin',
+        ];
+
+        const pattern = null;
+
+        const result = roms.filter(common.filterRomsFromPattern(pattern));
+
+        expect(result.length).to.eql(2);
+    });
+
+    it('should keep roms based on patterns', () => {
+        const roms =  [
+            '1_Foo.nes',
+            '2_Bar.bin',
+        ];
+
+        const pattern = "\.foo";
+
+        const result = roms.filter(common.filterRomsFromPattern(pattern));
+
+        expect(result.length).to.eql(2);
+    });
+});

--- a/src/common.spec.js
+++ b/src/common.spec.js
@@ -4,13 +4,13 @@ const common = require('./common');
 
 describe('common', () => {
     describe('filterRomsFromPattern', () => {
-        it('should filter roms based on patters', () => {
+        it('should filter roms based on patterns', () => {
             const roms =  [
                 '1_Foo.nes',
                 '2_Bar.bin',
             ];
 
-            const pattern = "\.bin";
+            const pattern = "\.bin$";
 
             const result = roms.filter(common.filterRomsFromPattern(pattern));
 
@@ -18,7 +18,22 @@ describe('common', () => {
             expect(result.length).to.eql(1);
         });
 
-        it('should filter roms based on patters', () => {
+        it('should filter roms based on patterns', () => {
+            const roms =  [
+                '1_Foo.nes',
+                '2_Bar.bin',
+            ];
+
+            const pattern = ".bin$";
+
+            const result = roms.filter(common.filterRomsFromPattern(pattern));
+
+            expect(result[0]).to.eql('1_Foo.nes');
+            expect(result.length).to.eql(1);
+        });
+
+
+        it('should not filter if the pattern is null', () => {
             const roms =  [
                 '1_Foo.nes',
                 '2_Bar.bin',
@@ -37,7 +52,7 @@ describe('common', () => {
                 '2_Bar.bin',
             ];
 
-            const pattern = "\.foo";
+            const pattern = "\.foo$";
 
             const result = roms.filter(common.filterRomsFromPattern(pattern));
 

--- a/src/common.spec.js
+++ b/src/common.spec.js
@@ -2,44 +2,46 @@ const { expect } = require('chai');
 
 const common = require('./common');
 
-describe('filterRomsFromPattern', () => {
-    it('should filter roms based on patters', () => {
-        const roms =  [
-            '1_Foo.nes',
-            '2_Bar.bin',
-        ];
+describe('common', () => {
+    describe('filterRomsFromPattern', () => {
+        it('should filter roms based on patters', () => {
+            const roms =  [
+                '1_Foo.nes',
+                '2_Bar.bin',
+            ];
 
-        const pattern = "\.bin";
+            const pattern = "\.bin";
 
-        const result = roms.filter(common.filterRomsFromPattern(pattern));
+            const result = roms.filter(common.filterRomsFromPattern(pattern));
 
-        expect(result[0]).to.eql('1_Foo.nes');
-        expect(result.length).to.eql(1);
-    });
+            expect(result[0]).to.eql('1_Foo.nes');
+            expect(result.length).to.eql(1);
+        });
 
-    it('should filter roms based on patters', () => {
-        const roms =  [
-            '1_Foo.nes',
-            '2_Bar.bin',
-        ];
+        it('should filter roms based on patters', () => {
+            const roms =  [
+                '1_Foo.nes',
+                '2_Bar.bin',
+            ];
 
-        const pattern = null;
+            const pattern = null;
 
-        const result = roms.filter(common.filterRomsFromPattern(pattern));
+            const result = roms.filter(common.filterRomsFromPattern(pattern));
 
-        expect(result.length).to.eql(2);
-    });
+            expect(result.length).to.eql(2);
+        });
 
-    it('should keep roms based on patterns', () => {
-        const roms =  [
-            '1_Foo.nes',
-            '2_Bar.bin',
-        ];
+        it('should keep roms based on patterns', () => {
+            const roms =  [
+                '1_Foo.nes',
+                '2_Bar.bin',
+            ];
 
-        const pattern = "\.foo";
+            const pattern = "\.foo";
 
-        const result = roms.filter(common.filterRomsFromPattern(pattern));
+            const result = roms.filter(common.filterRomsFromPattern(pattern));
 
-        expect(result.length).to.eql(2);
+            expect(result.length).to.eql(2);
+        });
     });
 });

--- a/src/config.js
+++ b/src/config.js
@@ -46,6 +46,7 @@ const getDefaultConfig = () => {
     "chatListCommand": "^list$",
     "chatCooldownGlobal": "60000",
     "chatCooldownUser": "60000",
+    "ignoreRomsPattern": "\.bin$",
     "redemptionName": "^swap$",
     "redepmtionRandomText": "^rng$",
     "randomOnly": false,

--- a/src/index.js
+++ b/src/index.js
@@ -59,14 +59,7 @@ const startServer = async () => {
 
     let filteredRoms = roms
       .map((rom) => rom.replace(/\.[a-zA-Z]+$/, ''))
-      .filter((rom) => {
-        if(!config.ignoreRomsPattern) {
-          return true;
-        } else {
-          const ignoreRomsRegExp = new RegExp(config.ignoreRomsPattern);
-          return (ignoreRomsRegExp.test(rom) === false);
-        }
-      })
+      .filter(common.filterRomsFromPattern(this.ignoreRomsPattern))
       .filter((rom) => rom !== 'DeleteMe')
     ;
 

--- a/src/index.js
+++ b/src/index.js
@@ -59,6 +59,14 @@ const startServer = async () => {
 
     let filteredRoms = roms
       .map((rom) => rom.replace(/\.[a-zA-Z]+$/, ''))
+      .filter((rom) => {
+        if(!config.ignoreRomsPattern) {
+          return true;
+        } else {
+          const ignoreRomsRegExp = new RegExp(config.ignoreRomsPattern);
+          return (ignoreRomsRegExp.test(rom) === false);
+        }
+      })
       .filter((rom) => rom !== 'DeleteMe')
     ;
 

--- a/src/swap.js
+++ b/src/swap.js
@@ -4,6 +4,7 @@ const fs = require('fs').promises;
 const chalk = require('chalk');
 
 const config = require('./config');
+const common = require('./common');
 
 const isRNG = (t) => new RegExp(config.redepmtionRandomText).test(t);
 
@@ -38,6 +39,7 @@ class RomShuffler {
 
       if(index && index !== '' && !isRNG(index)) {
         roms = roms
+          .filter(common.filterRomsFromPattern(this.ignoreRomsPattern))
           .filter((rom) => {
             const p = rom.split(TOKEN_SEPARATOR);
 
@@ -59,14 +61,7 @@ class RomShuffler {
       } else {
         roms = roms
           .filter((rom) => rom !== this.state.currentRom)
-          .filter((rom) => {
-            if(!config.ignoreRomsPattern) {
-              return true;
-            } else {
-              const ignoreRomsRegExp = new RegExp(this.ignoreRomsPattern);
-              return (ignoreRomsRegExp.test(rom) === false);
-            }
-          })
+          .filter(common.filterRomsFromPattern(this.ignoreRomsPattern))
           .filter((rom) => rom !== 'DeleteMe');
       }
 

--- a/src/swap.js
+++ b/src/swap.js
@@ -12,6 +12,8 @@ const TOKEN_SEPARATOR = "_";
 class RomShuffler {
   constructor() {
     this.state = {};
+
+    this.ignoreRomsPattern = config.ignoreRomsPattern;
     this.randomIfNoMatch = config.randomIfNoMatch;
     this.randomOnly = config.randomOnly;
   }
@@ -57,6 +59,14 @@ class RomShuffler {
       } else {
         roms = roms
           .filter((rom) => rom !== this.state.currentRom)
+          .filter((rom) => {
+            if(!config.ignoreRomsPattern) {
+              return true;
+            } else {
+              const ignoreRomsRegExp = new RegExp(this.ignoreRomsPattern);
+              return (ignoreRomsRegExp.test(rom) === false);
+            }
+          })
           .filter((rom) => rom !== 'DeleteMe');
       }
 

--- a/src/swap.spec.js
+++ b/src/swap.spec.js
@@ -214,6 +214,27 @@ describe('swap', () => {
   it('should be random on empty', async () => {
 
     const shuffler = new RomShuffler();
+    shuffler.ignoreRomsPattern = "\.bin$";
+
+    shuffler.state = {
+      currentRom: '1_Foo.nes'
+    };
+
+    shuffler.fetchCurrentRoms = sinon.spy(() => [
+      '1_Foo.nes',
+      '2_Bar.bin',
+    ]);
+
+    const rom = await shuffler.shuffle('2');
+
+    expect(rom).not.to.eql('2_Bar.bin');
+  });
+
+  it('should NOT ignore roms if the config is null', async () => {
+
+    const shuffler = new RomShuffler();
+    shuffler.ignoreRomsPattern = null;
+
     shuffler.state = {
       currentRom: '1_Foo.nes'
     };
@@ -235,7 +256,6 @@ describe('swap', () => {
 
     shuffler.fetchCurrentRoms = sinon.spy(() => [
       '2_Bar.cue',
-      '2_Bar.bin'
     ]);
 
     const rom = await shuffler.shuffle('2');

--- a/src/swap.spec.js
+++ b/src/swap.spec.js
@@ -214,7 +214,6 @@ describe('swap', () => {
   it('should be random on empty', async () => {
 
     const shuffler = new RomShuffler();
-
     shuffler.state = {
       currentRom: '1_Foo.nes'
     };
@@ -227,6 +226,21 @@ describe('swap', () => {
     const rom = await shuffler.shuffle('   ');
 
     expect(rom).to.eql('2_Bar.nes');
+  });
+
+  it('should ignore roms if the config is supplied', async () => {
+
+    const shuffler = new RomShuffler();
+    shuffler.ignoreRomsPattern = "^.bin$";
+
+    shuffler.fetchCurrentRoms = sinon.spy(() => [
+      '2_Bar.cue',
+      '2_Bar.bin'
+    ]);
+
+    const rom = await shuffler.shuffle('2');
+
+    expect(rom).to.eql('2_Bar.cue');
   });
 
   it('should be random on no match IF the randomIfNoMatch flag is true', async () => {


### PR DESCRIPTION
There are scenarios where users would want to play CD based files that require a `.bin` and `.cue` file. This option filters out the `.bin` file by default but allows other options as well.

refs #24