### PR TITLE
Patching windows version to run the correct executable

### DIFF
--- a/bizhawk-crowd-shuffler-win.bat
+++ b/bizhawk-crowd-shuffler-win.bat
@@ -3,5 +3,5 @@ SET PORT=7070
 SET CHANNEL=MyTwitchChannel
 SET BIZHAWK_PATH=..\\
 SET TWITCH_TOKEN=
-start bizhawk-crowd-shuffler.exe
+start bizhawk-crowd-shuffler-win.exe
 


### PR DESCRIPTION
There is an issue where a fresh install of release [v0.13.0](https://github.com/alexjpaz-twitch/bizhawk-crowd-shuffler/releases/tag/v0.13.0) doesn't not point to the correct executable file in Windows.

When the package is created it will create a file `bizhawk-crowd-shuffler-win.exe` for the windows distribution. As such we need to update `bizhawk-crowd-shuffler-win.bat` to point to the correct executable.

![image](https://github.com/alexjpaz-twitch/bizhawk-crowd-shuffler/assets/899367/7aa16266-f55b-4207-a94f-fa0a77fccd96)
