### PR TITLE
Add manual swap

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ These parameters control when the ROM should be swapped based on different Twitc
 - `swapOnSubMysteryGift`: Swap when someone gives mystery gift subs (default: `false`)
 - `swapOnGiftSubContinue`: Swap when someone continues a gifted sub (default: `false`)
 
+## Admin Tasks
+
+### Manually Swapping the Rom
+
+You can manually swap the roms by pressing "s" in the shuffler terminal.
 
 ## Miscellaneous
 

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ const { TwitchShufflerListener } = require('./twitch')
 const server = net.createServer();
 
 const fs = require('fs').promises;
+const readline = require('readline');
 
 const precondition = (expression, message) => {
   try {
@@ -156,9 +157,30 @@ const startServer = async () => {
       logger.info(chalk.purple(data));
     });
 
+    // Start listening for keypress events
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
     });
 
-}
+    readline.emitKeypressEvents(process.stdin);
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    }
+
+    process.stdin.on('keypress', (str, key) => {
+      if (key.name === 's') {
+        logger.info(chalk.yellow('Keystroke detected: Swapping ROM...'));
+        swap();
+      }
+      if (key.ctrl && key.name === 'c') {
+        process.exit(); // Allow graceful exit
+      }
+    });
+
+    logger.info(chalk.green('Press "s" to manually swap ROMs.'));
+  });
+};
 
 async function main() {
   try {

--- a/src/index.js
+++ b/src/index.js
@@ -160,7 +160,7 @@ const startServer = async () => {
     // Start listening for keypress events
     const rl = readline.createInterface({
       input: process.stdin,
-      output: process.stdout,
+      output: null,
     });
 
     readline.emitKeypressEvents(process.stdin);
@@ -171,7 +171,7 @@ const startServer = async () => {
     process.stdin.on('keypress', (str, key) => {
       if (key.name === 's') {
         logger.info(chalk.yellow('Keystroke detected: Swapping ROM...'));
-        swap();
+        swap(null, "manual");
       }
       if (key.ctrl && key.name === 'c') {
         process.exit(); // Allow graceful exit


### PR DESCRIPTION
## Overview

This change adds the ability to manually swap rims through the shuffler terminal. This can be used to test roms during the setup of the shuffler.

#### Swapping via the terminal 
The default keystroke for swapping roms is "s"

#### Screenshots

![image](https://github.com/user-attachments/assets/c40a82e9-a2ed-4d50-8158-abace8cefe62)

## References
- #42