### PR TITLE
Update ComfyJS to address PubSub deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "comfy.js": "^1.1.6",
+    "comfy.js": "^1.1.27",
     "lodash": "^4.17.20",
     "open": "^7.3.0",
     "pkg": "^4.4.9"


### PR DESCRIPTION
This change attempts to update the [ComfyJS](https://github.com/instafluff/ComfyJS) dependency in order to address the issue where the outdated version is using a [deprecated PubSub endpoint](https://dev.twitch.tv/docs/pubsub/).

refs https://github.com/alexjpaz-twitch/bizhawk-crowd-shuffler/issues/44